### PR TITLE
Cache tiles

### DIFF
--- a/tile_mosaics.py
+++ b/tile_mosaics.py
@@ -25,6 +25,7 @@ tiles_dir = 'mosaic_tiles'
 def tile_dir() -> str:
     return tiles_dir
 
+
 def tiling_w_o_overlap_NO_BBOXES(image_file, tile_size = (200, 200)):
 
     """
@@ -146,18 +147,7 @@ if __name__ == '__main__':
     elif args.directory:
         tile_dir(args.directory, (tw, th))
 
-    # Testing runtime of different functions
-    """ new_times = []
-    old_times = []
-    N = 100
-    for i in range(N):
-        start = time.time()
-        new_tiling_function(args.file, tw, th)
-        new_times.append(time.time()-start)
-        start = time.time()
-        tiling_w_o_overlap_NO_BBOXES(Image.open(args.file))
-        old_times.append(time.time()-start)
-
-    print("Mean execution time for new function:", np.mean(np.array(new_times)))
-    print("Mean execution time for old function:", np.mean(np.array(old_times))) """
+    # Run this to test:
+    # For dir : time python3 tile_mosaics.py -d [directory with mosaics]
+    # For file: time python3 tile_mosaics.py -f [mosaic file] 
 

--- a/tile_mosaics.py
+++ b/tile_mosaics.py
@@ -10,7 +10,13 @@ tiles_dir = 'mosaic_tiles'
 def get_tile_dir() -> str:
     return tiles_dir
 
-def tile_file(file, tile_size = (200,200)):
+def tile_mosaic(file: str, tile_size = (200,200)):
+    """
+    file is the filepath to the mosaic
+    tile_size is the size of the tiles you want to create
+
+    If the size of the image at file does not fit tile_size, it will be padded with 0 values
+    """
     if not file.endswith('.tif') and file.endswith('.TIF'):
         raise ValueError(f'File {file} is not a .tif or .TIF file')
     # make tile directory if it doesn't exist
@@ -20,7 +26,7 @@ def tile_file(file, tile_size = (200,200)):
 
     img_name = file.split(os.path.sep)[-1].split('.')[0]
     # open image and store as numpy array
-    img = Image.open(path).convert('L')
+    img = Image.open(file).convert('L')
     img_array = np.asarray(img)
 
     # pad image to be divisible by tw and th
@@ -45,11 +51,17 @@ def tile_file(file, tile_size = (200,200)):
                     tile_img.save(tile_name)
                     tile_count += 1
 
-def tile_dir(dir, tile_size = (200, 200)):
+def tile_mosaics_dir(dir: str, tile_size = (200, 200)):
+    """
+    dir is the name of the directory containing the mosaic files
+
+    This function will walk through dir and make tiles out of any .tif files it finds.
+    """
     # make tile directory if it doesn't exist
     if not os.path.exists(tiles_dir):
         os.mkdir(tiles_dir)
     tw, th = tile_size
+
     for (root, _, files) in os.walk(dir):
         for file in files:
             path = os.path.join(root, file)
@@ -83,33 +95,88 @@ def tile_dir(dir, tile_size = (200, 200)):
                             tile_img.save(tile_name)
                             tile_count += 1
             
-    print(f"Done tiling directory {dir}")
+    print("Done tiling!")
+
+
+def tile_mosaics_from_file(mosaic_file: str, tile_size = (200, 200)):
+    """
+    mosaic_file is the filepath of a file containing the filepaths of mosaic files separated by newline characters
+
+    This function will tile any .tif or .TIF files it finds in mosaic_file
+    """
+    # make tile directory if it doesn't exist
+    if not os.path.exists(tiles_dir):
+        os.mkdir(tiles_dir)
+    tw, th = tile_size
+    with open(mosaic_file, 'r') as f:
+        lines = f.readlines()
+        files = [path.strip() for path in lines]
+    
+    for file in files:
+        if not file.endswith('.tif') and not file.endswith('.TIF'):
+            continue
+        print(file)
+        img_name = file.split(os.path.sep)[-1].split('.')[0]
+        # Below is copied from tile_file
+
+        # open image and store as numpy array
+        img = Image.open(file).convert('L')
+        img_array = np.asarray(img)
+        
+        # pad image to be divisible by tw and th
+        padded_array = np.pad(img_array, ((0, int(img.width % tw)), (0, int(img.height % th))))
+        
+        # free up some memory
+        del img, img_array
+        gc.collect()
+
+        tile_count = 0
+        for row in range(0, padded_array.shape[0]-1, tw):
+            for col in range(0, padded_array.shape[1]-1, th):
+                # file name of new tile
+                tile_name = os.path.join(tiles_dir, f"{img_name}_tile_{tile_count}.tif")
+                # if tile already exists, skip
+                if not os.path.isfile(tile_name):
+                    # segment padded array into a tw by th tile
+                    tile_array = padded_array[row:row+tw][:,col:col+th]
+                    # if tile is all zeroes, skip
+                    if tile_array.any():
+                        tile_img = Image.fromarray(tile_array, 'L')
+                        tile_img.save(tile_name)
+                        tile_count += 1
+        
+    print("Done tiling!")
 
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('-tw', '--tile-width', type=int, default=200, help='width of the tiles')
     parser.add_argument('-th', '--tile-height', type=int, default=200, help='height of the tiles')
     parser.add_argument('-f', '--file', type=str, help='filepath for mosaic', default=None)
-    parser.add_argument('-d', '--directory', type=str, help='filepath for directory of mosaics', default=None)
+    parser.add_argument('-d', '--directory', type=str, help='filepath for mosaic directory', default=None)
+    parser.add_argument('-mf', '--mosaic-file', type=str, help='filepath for file of mosaics', default=None)
     #parser.add_argument('-p', '--padding', action='store_false', help='pad black pixels if tiles don\'t fit neatly (defaults to true)')         # padding 
     args = parser.parse_args()
-    
-    # if both or neither file or directory were passed
-    if bool(args.file == None) == bool(args.directory == None):
-        raise argparse.ArgumentTypeError('Include either \'--file\' or \'--directory\' in command line')
+
+    # if more than one of file, directory, or mosaic_file were passed
+    if int(bool(args.file)) + int(bool(args.directory)) + int(bool(args.mosaic_file)) != 1:
+        raise argparse.ArgumentTypeError('Include either \'--file\' or \'--directory\' or \'--mosaic-file\' in command line')
         return
 
     tw, th = args.tile_width, args.tile_height
     # tile a single .tif file
     if args.file:
-        tile_file(args.file, (tw, th))
+        tile_mosaic(args.file, (tw, th))
     # tile all the .tif files in a directory
     elif args.directory:
-        tile_dir(args.directory, (tw, th))
+        tile_mosaics_dir(args.directory, (tw, th))
+    # tile all .tif files contained in a file
+    elif args.mosaic_file:
+        tile_mosaics_from_file(args.mosaic_file, (tw, th))
 
     # Run this to test:
-    # For dir : time python3 tile_mosaics.py -d [directory with mosaics]
-    # For file: time python3 tile_mosaics.py -f [mosaic file] 
+    # For mosaic: time python3 tile_mosaics.py -f [mosaic]
+    # For mosaic file: time python3 tile_mosaics.py -mf [mosaic file] 
+    # For directory: time python3 tile_mosaics.py -d [directory] 
 
 if __name__ == '__main__':
     main()

--- a/tile_mosaics.py
+++ b/tile_mosaics.py
@@ -1,90 +1,44 @@
-import time
-
 import argparse
-import os, sys
+import os
 import gc
-import shutil
 from PIL import Image
 import numpy as np
 
-from utils import *
-import torch
-from datetime import date
-import albumentations as A
-from albumentations.pytorch import ToTensorV2
-
-parser = argparse.ArgumentParser() #an argument parser to collect arguments from the user
-parser.add_argument('-tw', '--tile-width', type=int, default=200, help='width of the tiles')
-parser.add_argument('-th', '--tile-height', type=int, default=200, help='height of the tiles')
-parser.add_argument('-f', '--file', type=str, help='filepath for mosaic', default=None)
-parser.add_argument('-d', '--directory', type=str, help='filepath for directory of mosaics', default=None)
-#parser.add_argument('-p', '--padding', action='store_false', help='pad black pixels if tiles don\'t fit neatly (defaults to true)')         # padding 
-
 tiles_dir = 'mosaic_tiles'
 
-def tile_dir() -> str:
+# for use outside of this file
+def get_tile_dir() -> str:
     return tiles_dir
 
-
-def tiling_w_o_overlap_NO_BBOXES(image_file, tile_size = (200, 200)):
-
-    """
-    A basic version of tiling w/o overlap that doesn't accept annotations.
-    Inputs:
-     - image: the image to tile w/o overlap
-     - tile_size: the size of the tile, in format (width, height)
-    Outputs:
-     - Nothing... tiles are saved as part of the process
-    """
-    img_name = image_file.split(os.path.sep)[-1].split('.')[0]
-    image = Image.open(image_file)
-    padded_image = pad_parent_for_tiles(image, tile_size)
-    tile_width, tile_height = tile_size
-    image_width, image_height = padded_image.size
-
-    #  freeing up memory
-    del image
-    gc.collect()
-
-    zero_tensor = torch.zeros(*(tile_size[0], tile_size[1], 3)) #represents a black tile
-
-    i = 0
-    for h in range(0, (image_height + 1) - tile_height, tile_height):
-        for w in range(0, (image_width + 1) - tile_width, tile_width):
-            coords = (w, h, w + tile_width, h + tile_height)
-            crop = A.Crop(*coords)
-            t = crop(image = np.array(padded_image))
-
-            tile = Image.fromarray(t['image'])
-            tensor_tile = torch.from_numpy(np.array(tile))
-            if not bool(torch.all(torch.eq(tensor_tile, zero_tensor))): #only saving if it's not an all-black tile
-                tile.save(os.path.join('mosaic_tiles', f'{img_name}_{i}.tif'))
-                i += 1
-
 def tile_file(file, tile_size = (200,200)):
+    if not file.endswith('.tif') and file.endswith('.TIF'):
+        raise ValueError(f'File {file} is not a .tif or .TIF file')
     # make tile directory if it doesn't exist
     if not os.path.exists(tiles_dir):
         os.mkdir(tiles_dir)
     tw, th = tile_size
+
     img_name = file.split(os.path.sep)[-1].split('.')[0]
     # open image and store as numpy array
-    img = Image.open(file).convert('L')
+    img = Image.open(path).convert('L')
     img_array = np.asarray(img)
 
     # pad image to be divisible by tw and th
-    padded_img_array = np.pad(img_array, ((0, int(img.width % tw)), (0, int(img.height % th))))
+    padded_array = np.pad(img_array, ((0, int(img.width % tw)), (0, int(img.height % th))))
     
     # free up some memory
     del img, img_array
     gc.collect()
 
     tile_count = 0
-    for row in range(0, padded_img_array.shape[0]-1, tw):
-        for col in range(0, padded_img_array.shape[1]-1, th):
+    for row in range(0, padded_array.shape[0]-1, tw):
+        for col in range(0, padded_array.shape[1]-1, th):
+            # file name of new tile
             tile_name = os.path.join(tiles_dir, f"{img_name}_tile_{tile_count}.tif")
             # if tile already exists, skip
             if not os.path.isfile(tile_name):
-                tile_array = padded_img_array[row:row+tw][:,col:col+th]
+                # segment padded array into a tw by th tile
+                tile_array = padded_array[row:row+tw][:,col:col+th]
                 # if tile is all zeroes, skip
                 if tile_array.any():
                     tile_img = Image.fromarray(tile_array, 'L')
@@ -99,49 +53,55 @@ def tile_dir(dir, tile_size = (200, 200)):
     for (root, _, files) in os.walk(dir):
         for file in files:
             path = os.path.join(root, file)
-            print(path)
-
+            print(f"Tiling {file}...")
+            img_name = file.split('.')[0]
             # Below is copied from tile_file
 
-            img_name = path.split(os.path.sep)[-1].split('.')[0]
             # open image and store as numpy array
             img = Image.open(path).convert('L')
             img_array = np.asarray(img)
 
             # pad image to be divisible by tw and th
-            padded_img_array = np.pad(img_array, ((0, int(img.width % tw)), (0, int(img.height % th))))
+            padded_array = np.pad(img_array, ((0, int(img.width % tw)), (0, int(img.height % th))))
             
             # free up some memory
             del img, img_array
             gc.collect()
 
             tile_count = 0
-            for row in range(0, padded_img_array.shape[0]-1, tw):
-                for col in range(0, padded_img_array.shape[1]-1, th):
+            for row in range(0, padded_array.shape[0]-1, tw):
+                for col in range(0, padded_array.shape[1]-1, th):
+                    # file name of new tile
                     tile_name = os.path.join(tiles_dir, f"{img_name}_tile_{tile_count}.tif")
                     # if tile already exists, skip
                     if not os.path.isfile(tile_name):
-                        tile_array = padded_img_array[row:row+tw][:,col:col+th]
+                        # segment padded array into a tw by th tile
+                        tile_array = padded_array[row:row+tw][:,col:col+th]
                         # if tile is all zeroes, skip
                         if tile_array.any():
                             tile_img = Image.fromarray(tile_array, 'L')
                             tile_img.save(tile_name)
                             tile_count += 1
+            
+    print(f"Done tiling directory {dir}")
 
-
-
-
-if __name__ == '__main__':
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-tw', '--tile-width', type=int, default=200, help='width of the tiles')
+    parser.add_argument('-th', '--tile-height', type=int, default=200, help='height of the tiles')
+    parser.add_argument('-f', '--file', type=str, help='filepath for mosaic', default=None)
+    parser.add_argument('-d', '--directory', type=str, help='filepath for directory of mosaics', default=None)
+    #parser.add_argument('-p', '--padding', action='store_false', help='pad black pixels if tiles don\'t fit neatly (defaults to true)')         # padding 
     args = parser.parse_args()
     
     # if both or neither file or directory were passed
     if bool(args.file == None) == bool(args.directory == None):
         raise argparse.ArgumentTypeError('Include either \'--file\' or \'--directory\' in command line')
-        sys.exit(1)
+        return
 
     tw, th = args.tile_width, args.tile_height
     # tile a single .tif file
-    if args.file and (args.file.endswith(".tif") or args.file.endswith(".TIF")):
+    if args.file:
         tile_file(args.file, (tw, th))
     # tile all the .tif files in a directory
     elif args.directory:
@@ -150,4 +110,7 @@ if __name__ == '__main__':
     # Run this to test:
     # For dir : time python3 tile_mosaics.py -d [directory with mosaics]
     # For file: time python3 tile_mosaics.py -f [mosaic file] 
+
+if __name__ == '__main__':
+    main()
 

--- a/tile_mosaics.py
+++ b/tile_mosaics.py
@@ -1,0 +1,163 @@
+import time
+
+import argparse
+import os, sys
+import gc
+import shutil
+from PIL import Image
+import numpy as np
+
+from utils import *
+import torch
+from datetime import date
+import albumentations as A
+from albumentations.pytorch import ToTensorV2
+
+parser = argparse.ArgumentParser() #an argument parser to collect arguments from the user
+parser.add_argument('-tw', '--tile-width', type=int, default=200, help='width of the tiles')
+parser.add_argument('-th', '--tile-height', type=int, default=200, help='height of the tiles')
+parser.add_argument('-f', '--file', type=str, help='filepath for mosaic', default=None)
+parser.add_argument('-d', '--directory', type=str, help='filepath for directory of mosaics', default=None)
+#parser.add_argument('-p', '--padding', action='store_false', help='pad black pixels if tiles don\'t fit neatly (defaults to true)')         # padding 
+
+tiles_dir = 'mosaic_tiles'
+
+def tile_dir() -> str:
+    return tiles_dir
+
+def tiling_w_o_overlap_NO_BBOXES(image_file, tile_size = (200, 200)):
+
+    """
+    A basic version of tiling w/o overlap that doesn't accept annotations.
+    Inputs:
+     - image: the image to tile w/o overlap
+     - tile_size: the size of the tile, in format (width, height)
+    Outputs:
+     - Nothing... tiles are saved as part of the process
+    """
+    img_name = image_file.split(os.path.sep)[-1].split('.')[0]
+    image = Image.open(image_file)
+    padded_image = pad_parent_for_tiles(image, tile_size)
+    tile_width, tile_height = tile_size
+    image_width, image_height = padded_image.size
+
+    #  freeing up memory
+    del image
+    gc.collect()
+
+    zero_tensor = torch.zeros(*(tile_size[0], tile_size[1], 3)) #represents a black tile
+
+    i = 0
+    for h in range(0, (image_height + 1) - tile_height, tile_height):
+        for w in range(0, (image_width + 1) - tile_width, tile_width):
+            coords = (w, h, w + tile_width, h + tile_height)
+            crop = A.Crop(*coords)
+            t = crop(image = np.array(padded_image))
+
+            tile = Image.fromarray(t['image'])
+            tensor_tile = torch.from_numpy(np.array(tile))
+            if not bool(torch.all(torch.eq(tensor_tile, zero_tensor))): #only saving if it's not an all-black tile
+                tile.save(os.path.join('mosaic_tiles', f'{img_name}_{i}.tif'))
+                i += 1
+
+def tile_file(file, tile_size = (200,200)):
+    # make tile directory if it doesn't exist
+    if not os.path.exists(tiles_dir):
+        os.mkdir(tiles_dir)
+    tw, th = tile_size
+    img_name = file.split(os.path.sep)[-1].split('.')[0]
+    # open image and store as numpy array
+    img = Image.open(file).convert('L')
+    img_array = np.asarray(img)
+
+    # pad image to be divisible by tw and th
+    padded_img_array = np.pad(img_array, ((0, int(img.width % tw)), (0, int(img.height % th))))
+    
+    # free up some memory
+    del img, img_array
+    gc.collect()
+
+    tile_count = 0
+    for row in range(0, padded_img_array.shape[0]-1, tw):
+        for col in range(0, padded_img_array.shape[1]-1, th):
+            tile_name = os.path.join(tiles_dir, f"{img_name}_tile_{tile_count}.tif")
+            # if tile already exists, skip
+            if not os.path.isfile(tile_name):
+                tile_array = padded_img_array[row:row+tw][:,col:col+th]
+                # if tile is all zeroes, skip
+                if tile_array.any():
+                    tile_img = Image.fromarray(tile_array, 'L')
+                    tile_img.save(tile_name)
+                    tile_count += 1
+
+def tile_dir(dir, tile_size = (200, 200)):
+    # make tile directory if it doesn't exist
+    if not os.path.exists(tiles_dir):
+        os.mkdir(tiles_dir)
+    tw, th = tile_size
+    for (root, _, files) in os.walk(dir):
+        for file in files:
+            path = os.path.join(root, file)
+            print(path)
+
+            # Below is copied from tile_file
+
+            img_name = path.split(os.path.sep)[-1].split('.')[0]
+            # open image and store as numpy array
+            img = Image.open(path).convert('L')
+            img_array = np.asarray(img)
+
+            # pad image to be divisible by tw and th
+            padded_img_array = np.pad(img_array, ((0, int(img.width % tw)), (0, int(img.height % th))))
+            
+            # free up some memory
+            del img, img_array
+            gc.collect()
+
+            tile_count = 0
+            for row in range(0, padded_img_array.shape[0]-1, tw):
+                for col in range(0, padded_img_array.shape[1]-1, th):
+                    tile_name = os.path.join(tiles_dir, f"{img_name}_tile_{tile_count}.tif")
+                    # if tile already exists, skip
+                    if not os.path.isfile(tile_name):
+                        tile_array = padded_img_array[row:row+tw][:,col:col+th]
+                        # if tile is all zeroes, skip
+                        if tile_array.any():
+                            tile_img = Image.fromarray(tile_array, 'L')
+                            tile_img.save(tile_name)
+                            tile_count += 1
+
+
+
+
+if __name__ == '__main__':
+    args = parser.parse_args()
+    
+    # if both or neither file or directory were passed
+    if bool(args.file == None) == bool(args.directory == None):
+        raise argparse.ArgumentTypeError('Include either \'--file\' or \'--directory\' in command line')
+        sys.exit(1)
+
+    tw, th = args.tile_width, args.tile_height
+    # tile a single .tif file
+    if args.file and (args.file.endswith(".tif") or args.file.endswith(".TIF")):
+        tile_file(args.file, (tw, th))
+    # tile all the .tif files in a directory
+    elif args.directory:
+        tile_dir(args.directory, (tw, th))
+
+    # Testing runtime of different functions
+    """ new_times = []
+    old_times = []
+    N = 100
+    for i in range(N):
+        start = time.time()
+        new_tiling_function(args.file, tw, th)
+        new_times.append(time.time()-start)
+        start = time.time()
+        tiling_w_o_overlap_NO_BBOXES(Image.open(args.file))
+        old_times.append(time.time()-start)
+
+    print("Mean execution time for new function:", np.mean(np.array(new_times)))
+    print("Mean execution time for old function:", np.mean(np.array(old_times))) """
+


### PR DESCRIPTION
# See issue #3 

## Functionality
To tile a single mosaic, run the following command:
```shell
python3 tile_mosaic.py -f [mosaic_file]
```

To tile a directory of mosaics, run the following command:
```shell
python3 tile_mosaic.py -d [mosaic_dir]
```

To use a file containing the mosaic filepaths, run the following command:
```shell
python3 tile_mosaic.py -mf [mosaic_file_filepath]
```

The default tile size is (200,200) but can be altered with the -tw and -th flags followed by an integer in the command line.  Tiles are outputted in the "mosaic_tiles" directory in the format "{img_name}_tile_{tile #}.tif" where "img_name" is the name of the image the tile comes from.

## Testing
---
### Testing a file of mosaics

Pass the file of mosaics into the program, wait for it to finish. Go into the mosaic_tiles directory and compare a tile in there to the image it corresponds to. I used 20180320_212958_600_9152_tile_0.tif which corresponds to the upper left corner of 20180320_212958_600_9152.tif.

### Testing a single mosaic

Pass the file into the program and wait for it to finish. 
- Compare the size of the image to the number of tiles created
- Compare a tile to the original image to see if they match
For a point of reference, 20180320_212958_600_9152.tif is known to have 28 200 by 200 tiles.

If this is being run on the remote machines, you must scp the images onto a local machine before being able to view them