### PR TITLE
Preparing pipeline for 2018 mosaics

### DIFF
--- a/miscellaneous/jp2_mosaic_conversion.ipynb
+++ b/miscellaneous/jp2_mosaic_conversion.ipynb
@@ -83,7 +83,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3.9.2 64-bit",
    "language": "python",
    "name": "python3"
   },
@@ -97,7 +97,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.16"
+   "version": "3.9.2"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "aee8b7b246df8f9039afb4144a1f6fd8d2ca17a180786b69acc140d282b71a49"
+   }
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Small tweaks to make the pipeline compatible with the 2018 mosaics:
- Removed max image size in `PIL`.
- Added code to remove alpha channel from incoming `jp2` images.
- Converted to RGB (3-channel) since this is what APSDNet expects.

**Everything seems to be working ok so far. Can read in one of the 2018 mosaics, extract some tiles, and predict on them!**