### PR TITLE
Changed `full_pipeline.py` to use cached tiles and `tile_mosaics.py` for tiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,9 @@ To run `final_pipeline.py`, use the command `python3 final_pipeline.py MOSAIC_FP
 5. Run `source ~/miniconda3/etc/profile.d/conda.sh`. This will have to be done every time a new lab session is opened. 
 6. Install the [nightly build of PyTorch](https://pytorch.org/get-started/locally/) using conda.
 6. Install required packages using `pip install -r lab_requirements.txt`.
+
+## Running the pipeline
+1. Collect mosaics with the following command: `python3 miscellaneous/collect_2018_mosaics.py [mosaic_directory]`
+2. Make a file called mosaic_filepaths.txt with the filepaths of each mosaic file separated by a newline
+3. Cache tiles by passing mosaic_filepaths.txt to tile_mosaics.py with the following command: `python3 tile_mosaics.py -mf mosaic_filepaths.txt`
+4. Predict the mosaics in mosaic_filepaths.txt with the following command: `python3 full_pipeline.py mosaic_filepaths.txt [MODEL_NAME] [MODEL_FP] [RESULTS_FP]`

--- a/full_pipeline.py
+++ b/full_pipeline.py
@@ -1,3 +1,4 @@
+import glob
 import os
 import sys
 import shutil
@@ -13,7 +14,7 @@ import albumentations as A
 from albumentations.pytorch import ToTensorV2
 import torch
 from torch.utils.data import Dataset, DataLoader
-
+from tile_mosaics import tile_mosaic, get_tile_dir
 
 
 
@@ -46,6 +47,7 @@ def run_pipeline(mosaic_fp, model_name, model_save_fp, write_results_fp, num_wor
     start_time = time.time()
 
     #Loading in multiple images in one file 
+    tile_dir = get_tile_dir()
     with open(mosaic_fp, 'r') as f:
         file_paths = f.readlines()
     
@@ -54,23 +56,8 @@ def run_pipeline(mosaic_fp, model_name, model_save_fp, write_results_fp, num_wor
 
     #Store filepaths to mosaics in text file
     for i, path in enumerate(file_paths):
-        mosaic = Image.open(path)
-        
-        
-        #TILE MOSAIC:
-        print(f'Tiling mosaic of size {mosaic.size[0]}x{mosaic.size[1]}...')
-
-        if os.path.isdir('mosaic_tiles'): #if the tile save directory exists, it will be removed
-            shutil.rmtree('mosaic_tiles')
-        os.mkdir('mosaic_tiles') #create an empty directory
-
-        tile_size = (200, 200)
-        tiling_w_o_overlap_NO_BBOXES(mosaic, tile_size = tile_size) #tile the mosaic into non-overlapping tiles + save tiles
-
-        print('Done tiling mosaic!')
-
         #PREDICT ON TILES:
-        tile_dataset = BirdDatasetPREDICTION('mosaic_tiles', model_name)
+        tile_dataset = BirdDatasetPREDICTION(path, model_name)
         tile_dataloader = DataLoader(tile_dataset, batch_size = 8, shuffle = False, collate_fn = collate_tiles_PREDICTION, num_workers = num_workers)
         print(f'\nPredicting on {len(tile_dataset)} tiles...')
         
@@ -170,7 +157,7 @@ def run_pipeline(mosaic_fp, model_name, model_save_fp, write_results_fp, num_wor
         curr_time = str(time.strftime('%H:%M:%S', time.localtime()))
         curr_date = str(date.today())
         pipeline_time = time.time() - start_time
-        new_row = [curr_date, curr_time, mosaic_fp, len(tile_dataset), int(total_count), model_name, pipeline_time, pred_time] #all of the run results to include
+        new_row = [curr_date, curr_time, path, len(tile_dataset), int(total_count), model_name, pipeline_time, pred_time] #all of the run results to include
 
 
     
@@ -227,13 +214,25 @@ class BirdDatasetPREDICTION(Dataset):
     """
     A reduced version of BirdDataset to help read in and preprocess mosaic tiles for prediction.
     Inputs:
-     - root_dir: the root directory for mosaic tiles
+     - mosaic_fp: the filepath of the full mosaic, assume it exists
      - model_name: either Faster R-CNN or ASPDNet
     """
 
-    def __init__(self, root_dir, model_name):
-        self.root_dir = root_dir
-        self.tile_fps = sorted(os.listdir(self.root_dir))
+    def __init__(self, mosaic_fp, model_name):
+        self.mosaic_fp = mosaic_fp
+        tile_dir = get_tile_dir()
+        self.tile_fps = []
+        #Store filepaths to mosaics in text file
+            
+        # takes out everything before the filename as well as the file ending (i.e. "/path/to/file/img_name.tif" becomes "img_name")
+        img_name = ''.join(mosaic_fp.split(os.path.sep)[-1].split('.')[:-1])
+        # search for cached tiles
+        tiles = glob.glob(f'./{tile_dir}/{img_name}-tile*')
+
+        if len(tiles) == 0:
+            tile_mosaic(mosaic_fp)
+            tiles = glob.glob(f'./{tile_dir}/{img_name}-tile*')
+        self.tile_fps = sorted(tiles)
 
         self.transforms = []
         if model_name == 'ASPDNet': #PyTorch's Faster R-CNN impelementation handles normalization...
@@ -242,7 +241,7 @@ class BirdDatasetPREDICTION(Dataset):
         self.transforms = A.Compose(self.transforms)
 
     def __getitem__(self, index):
-        tile_fp = os.path.join(self.root_dir, self.tile_fps[index])
+        tile_fp = self.tile_fps[index]
         tile_num = int(tile_fp.split('_')[-1].replace('.tif', '')) #grabbing this for saving preds
         tile = Image.open(tile_fp).convert('RGB')
         tile = np.array(tile)

--- a/tile_mosaics.py
+++ b/tile_mosaics.py
@@ -10,20 +10,8 @@ tiles_dir = 'mosaic_tiles'
 def get_tile_dir() -> str:
     return tiles_dir
 
-def tile_mosaic(file: str, tile_size = (200,200)):
-    """
-    file is the filepath to the mosaic
-    tile_size is the size of the tiles you want to create
-
-    If the size of the image at file does not fit tile_size, it will be padded with 0 values
-    """
-    if not file.endswith('.tif') and file.endswith('.TIF'):
-        raise ValueError(f'File {file} is not a .tif or .TIF file')
-    # make tile directory if it doesn't exist
-    if not os.path.exists(tiles_dir):
-        os.mkdir(tiles_dir)
+def tile_file(file: str, tile_size = (200,200)):
     tw, th = tile_size
-
     img_name = file.split(os.path.sep)[-1].split('.')[0]
     # open image and store as numpy array
     img = Image.open(file).convert('L')
@@ -40,7 +28,7 @@ def tile_mosaic(file: str, tile_size = (200,200)):
     for row in range(0, padded_array.shape[0]-1, tw):
         for col in range(0, padded_array.shape[1]-1, th):
             # file name of new tile
-            tile_name = os.path.join(tiles_dir, f"{img_name}_tile_{tile_count}.tif")
+            tile_name = os.path.join(tiles_dir, f"{img_name}-tile_{tile_count}.tif")
             # if tile already exists, skip
             if not os.path.isfile(tile_name):
                 # segment padded array into a tw by th tile
@@ -51,6 +39,20 @@ def tile_mosaic(file: str, tile_size = (200,200)):
                     tile_img.save(tile_name)
                     tile_count += 1
 
+def tile_mosaic(file: str, tile_size = (200,200)):
+    """
+    file is the filepath to the mosaic
+    tile_size is the size of the tiles you want to create
+
+    If the size of the image at file does not fit tile_size, it will be padded with 0 values
+    """
+    if not file.endswith('.tif') and file.endswith('.TIF'):
+        raise ValueError(f'File {file} is not a .tif or .TIF file')
+    # make tile directory if it doesn't exist
+    if not os.path.exists(tiles_dir):
+        os.mkdir(tiles_dir)
+    tile_file(file, tile_size)
+
 def tile_mosaics_dir(dir: str, tile_size = (200, 200)):
     """
     dir is the name of the directory containing the mosaic files
@@ -60,40 +62,12 @@ def tile_mosaics_dir(dir: str, tile_size = (200, 200)):
     # make tile directory if it doesn't exist
     if not os.path.exists(tiles_dir):
         os.mkdir(tiles_dir)
-    tw, th = tile_size
 
     for (root, _, files) in os.walk(dir):
         for file in files:
             path = os.path.join(root, file)
             print(f"Tiling {file}...")
-            img_name = file.split('.')[0]
-            # Below is copied from tile_file
-
-            # open image and store as numpy array
-            img = Image.open(path).convert('L')
-            img_array = np.asarray(img)
-
-            # pad image to be divisible by tw and th
-            padded_array = np.pad(img_array, ((0, int(img.width % tw)), (0, int(img.height % th))))
-            
-            # free up some memory
-            del img, img_array
-            gc.collect()
-
-            tile_count = 0
-            for row in range(0, padded_array.shape[0]-1, tw):
-                for col in range(0, padded_array.shape[1]-1, th):
-                    # file name of new tile
-                    tile_name = os.path.join(tiles_dir, f"{img_name}_tile_{tile_count}.tif")
-                    # if tile already exists, skip
-                    if not os.path.isfile(tile_name):
-                        # segment padded array into a tw by th tile
-                        tile_array = padded_array[row:row+tw][:,col:col+th]
-                        # if tile is all zeroes, skip
-                        if tile_array.any():
-                            tile_img = Image.fromarray(tile_array, 'L')
-                            tile_img.save(tile_name)
-                            tile_count += 1
+            tile_file(path, tile_size)
             
     print("Done tiling!")
 
@@ -116,34 +90,7 @@ def tile_mosaics_from_file(mosaic_file: str, tile_size = (200, 200)):
         if not file.endswith('.tif') and not file.endswith('.TIF'):
             continue
         print(file)
-        img_name = file.split(os.path.sep)[-1].split('.')[0]
-        # Below is copied from tile_file
-
-        # open image and store as numpy array
-        img = Image.open(file).convert('L')
-        img_array = np.asarray(img)
-        
-        # pad image to be divisible by tw and th
-        padded_array = np.pad(img_array, ((0, int(img.width % tw)), (0, int(img.height % th))))
-        
-        # free up some memory
-        del img, img_array
-        gc.collect()
-
-        tile_count = 0
-        for row in range(0, padded_array.shape[0]-1, tw):
-            for col in range(0, padded_array.shape[1]-1, th):
-                # file name of new tile
-                tile_name = os.path.join(tiles_dir, f"{img_name}_tile_{tile_count}.tif")
-                # if tile already exists, skip
-                if not os.path.isfile(tile_name):
-                    # segment padded array into a tw by th tile
-                    tile_array = padded_array[row:row+tw][:,col:col+th]
-                    # if tile is all zeroes, skip
-                    if tile_array.any():
-                        tile_img = Image.fromarray(tile_array, 'L')
-                        tile_img.save(tile_name)
-                        tile_count += 1
+        tile_file(file, tile_size)
         
     print("Done tiling!")
 


### PR DESCRIPTION
## Description
`full_pipeline.py` would previously do the following: tile an image, save the tiles into `mosaic_tiles`, predict on all the tiles in mosaic tiles and count the sum as the total prediction, delete `mosaic_tiles`, repeat for next image. This was changed to: pass `mosaic_filepaths.txt` to `full_pipeline.py`, for each mosaic filepath check if there are tiles already in `mosaic_tiles`, if not tile the image and save them into `mosaic_tiles`, if so use those tiles for prediction, don't delete `mosaic_tiles`, go onto next mosaic filepath.

## Testing
- Fill in a file called `mosaic_filepaths.txt` with all the mosaics you want to tile.
- Pass that file into `tile_mosaics.py` with the following command: `python3 tile_mosaics.py -mf mosaic_filepaths.txt`
Check in the `mosaic_tiles` folder to see if tiles for every mosaic are in it.  For example, if a mosaic called `img_name.tif` was passed to `tile_mosaics.py`, its corresponding tiles would be called `img_name-tile_##.tif`.
- Pass `mosaic_filepaths.txt` to `full_pipeline.py` to predict on all of the new tiles. 
Confirm that `full_pipeline.py` predicted on every file by checking the outputted csv and looking for each filepath in `mosaic_filepaths.txt`.