### PR TITLE
WIP: fixing `full_pipeline.py` warnings

### DIFF
--- a/density_estimation/ASPDNet/model.py
+++ b/density_estimation/ASPDNet/model.py
@@ -59,7 +59,7 @@ class ASPDNet(nn.Module):
         self.output_layer = nn.Conv2d(64, 1, kernel_size=1)
 
         if not load_weights:
-            mod = models.vgg16(pretrained = True)
+            mod = models.vgg16(weights="VGG16_Weights.IMAGENET1K_V1") 
             self._initialize_weights()
             for i in range(len(self.frontend.state_dict().items())):
                 list(self.frontend.state_dict().items())[i][1].data[:] = list(mod.state_dict().items())[i][1].data[:]

--- a/full_pipeline.py
+++ b/full_pipeline.py
@@ -103,7 +103,7 @@ def run_pipeline(mosaic_fp, model_name, model_save_fp, write_results_fp, num_wor
         elif model_name == 'ASPDNet':
             if model_save_fp.endswith('.pth'):
                 model = ASPDNet(allow_neg_densities = False).to(device)
-                model.load_state_dict(torch.load(model_save_fp))
+                model.load_state_dict(torch.load(model_save_fp)) 
                 pl_model = ASPDNetLightning(model)
             elif model_save_fp.endswith('.ckpt'):
                 model = ASPDNet(allow_neg_densities = False).to(device)


### PR DESCRIPTION
Closes #19.

The pre-trained `VGG-16` is uses the updated command for ImageNet weights, which fixed the warning. (Still need to see if these are the correct weights--most easily checked using an image from the original dataset's test set to see if the expected count is obtained with the paper's pre-trained ASPDNet weights.) 

Multiple miscellaneous warnings still need to be dealt with here.